### PR TITLE
feat: post-main image in post-detail page

### DIFF
--- a/_posts/20230924_markdown-test.md
+++ b/_posts/20230924_markdown-test.md
@@ -5,7 +5,7 @@ date:   2021-12-30 01:04:25
 series: "kramdown-test"
 summary: "마크다운 제대로 잘 나오는 지 테스트"
 tags: ["markdown", "test", "kramdown", "jekyll"]
-image: ""
+image: "/images/posts/markdown-test/main.jpg"
 ---
 
 # H1

--- a/src/app/posts/[serialCode]/page.tsx
+++ b/src/app/posts/[serialCode]/page.tsx
@@ -6,6 +6,7 @@ import {getInternalAPIHost} from '@/apis/internal';
 import Utterances from '@/components/common/Utterances';
 import PostPrevAndNextContainer from '@/components/post/detail/PostPrevAndNextContainer';
 import NavbarPostReadProgress from '@/components/common/NavbarPostReadProgress';
+import PostTitleImage from '@/components/post/detail/PostTitleImage';
 
 interface PostDetailPageArgs {
     serialCode: string;
@@ -39,6 +40,10 @@ const PostDetailPage = async ({ params }: {params: PostDetailPageArgs}) => {
                 <NavbarPostReadProgress />
             </div>
             <PostTitleContainer title={data.title} date={new Date(data.date)} series={data.series} tags={data.tags} />
+            {
+                data.image &&
+                <PostTitleImage image={data.image} />
+            }
             <PostContentContainer content={data.content} />
             <PostPrevAndNextContainer prev={data.prev} next={data.next} />
             <Utterances />

--- a/src/components/post/detail/PostTitleImage.tsx
+++ b/src/components/post/detail/PostTitleImage.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import styled from 'styled-components';
+import Image from 'next/image';
+
+interface PostTitleImageParams {
+    image: string;
+}
+
+
+const PostTitleImage = (params: PostTitleImageParams) => {
+    const { image } = params;
+    return (
+        <Layout>
+            <Image
+                src={image}
+                alt="title image"
+                width="0" height="0"
+                sizes="100vw"
+                style={{
+                    width: "100%",
+                    height: "auto"
+                }}
+            />
+        </Layout>
+    );
+}
+
+export default PostTitleImage;
+
+
+const Layout = styled.div`
+    width: 100%;
+`


### PR DESCRIPTION
## 개요

* 포스트에 메인 이미지 URL을 입력했으면, 포스트 페이지의 맨 상단에 메인 이미지가 출력되게 구현